### PR TITLE
Removed semicolons, Python is a semicolon-free language except where usin

### DIFF
--- a/go.py
+++ b/go.py
@@ -5,7 +5,7 @@ import argparse
 
 commands = ["build", "run", "ref", "cmp"]
 parser = argparse.ArgumentParser(description='Broadway Command Center')
-parser.add_argument('command', help="Possible commands: [%s]" % ", ".join(commands));
+parser.add_argument('command', help="Possible commands: [%s]" % ", ".join(commands))
 
 args = parser.parse_args()
 
@@ -14,11 +14,11 @@ if args.command not in commands:
 
 if args.command == "build":
     os.chdir("Show")
-    os.system("scons");
+    os.system("scons")
     os.chdir("..")
 
 scripts = ['Play/play.js', 'Play/util.js', 'Play/bits.js', 'Play/common.js', 'Play/ps.js', 'Play/nal.js', 'Play/shell.js']
-scriptsCommad = " ".join(["-s %s" % s for s in scripts]);
+scriptsCommad = " ".join(["-s %s" % s for s in scripts])
 
 if args.command == "run":
     os.system("Show/bin/player -j " + scriptsCommad + " -a \"Media/admiral.264\"")
@@ -27,12 +27,12 @@ if args.command == "run":
 #     os.system("gdb --args Show/bin/player Play/play.js Play/util.js Play/bits.js Play/common.js Play/ps.js Play/nal.js Play/shell.js")
 
 if args.command == "ref":
-    os.system("Show/bin/player -r -a \"Media/admiral.264\"");
+    os.system("Show/bin/player -r -a \"Media/admiral.264\"")
 
 if args.command == "cmp":
-    os.system("Show/bin/player -r -a \"Media/admiral.264\" > ref.out");
-    os.system("Show/bin/player -j " + scriptsCommad + " -a \"Media/admiral.264\" > jsr -> jsr.out");
+    os.system("Show/bin/player -r -a \"Media/admiral.264\" > ref.out")
+    os.system("Show/bin/player -j " + scriptsCommad + " -a \"Media/admiral.264\" > jsr -> jsr.out")
 
 
 
-sys.exit(0);
+sys.exit(0)


### PR DESCRIPTION
Removed semicolons, Python is a semicolon-free language except where using multiple statements on a single line
