### PR TITLE
Clone only the needed portion of an ArrayBuffer

### DIFF
--- a/Player/avc-worker.js
+++ b/Player/avc-worker.js
@@ -17,6 +17,11 @@ avc.onPictureDecoded = function (buffer, width, height) {
   if (config && config.sendBufferOnPictureDecoded !== undefined) {
     buffer = config.sendBufferOnPictureDecoded ? buffer : null;
   }
+  // 'buffer' is a view of a large ArrayBuffer. Only clone the portion in the
+  // view.
+  if (buffer) {
+    buffer = Uint8Array(buffer);
+  }
   socket.sendMessage("on-picture-decoded", {picture: buffer, width: width, height: height});
 }
 

--- a/Player/mp4.js
+++ b/Player/mp4.js
@@ -866,7 +866,9 @@ var MP4Player = (function reader() {
         if (this.useWorkers) {
           var avcWorker = this.avcWorker;
           video.getSampleNALUnits(pic).forEach(function (nal) {
-            avcWorker.sendMessage("decode-sample", nal);
+            // Copy the sample so that we only do a structured clone of the
+            // region of interest
+            avcWorker.sendMessage("decode-sample", Uint8Array(nal));
           });
         } else {
           var avc = this.avc;


### PR DESCRIPTION
According to the spec, when cloning a typed array that is a view of a larger buffer, the entire buffer should be cloned and then the view recreated on that buffer. Firefox used to copy only the portion within the view, which observably differs from the spec. Its behavior changed long ago, which can result in hugely inflated memory usage.
