### PR TITLE
Added readme note for python version requirement

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ Building the demo:
 
 Install and configure Emscripten (https://github.com/kripken/emscripten)
 
-The code for the demo is in the Decoder folder, to build it run the make.py python script.
+The code for the demo is in the Decoder folder, to build it run the make.py python script. (Requires at least python 2.7)
 
 Encoding Video
 ==============


### PR DESCRIPTION
Building with emscripten requires at least Python 2.7. Simply added a note on the readme.