### PR TITLE
Webgl changes

### DIFF
--- a/Player/WebGLCanvas.js
+++ b/Player/WebGLCanvas.js
@@ -41,10 +41,10 @@
 
 
 /**
- * This class can be used to render output pictures from an H264bsdDecoder to a canvas element.
+ * This class can be used to render output pictures from a video decoder to a canvas element.
  * If available the content is rendered using WebGL.
  */
-  function H264bsdCanvas(canvas, forceNoGL, contextOptions) {
+  function WebGLCanvas(canvas, forceNoGL, contextOptions) {
     this.canvasElement = canvas;
     this.contextOptions = contextOptions;
 
@@ -60,14 +60,14 @@
 /**
  * Returns true if the canvas supports WebGL
  */
-H264bsdCanvas.prototype.isWebGL = function() {
+WebGLCanvas.prototype.isWebGL = function() {
     return this.contextGL;
 };
 
 /**
  * Create the GL context from the canvas element
  */
-  H264bsdCanvas.prototype.initContextGL = function() {
+  WebGLCanvas.prototype.initContextGL = function() {
     var canvas = this.canvasElement;
     var gl = null;
 
@@ -100,7 +100,7 @@ H264bsdCanvas.prototype.isWebGL = function() {
 /**
  * Initialize GL shader program
  */
-H264bsdCanvas.prototype.initProgram = function() {
+WebGLCanvas.prototype.initProgram = function() {
     var gl = this.contextGL;
 
     var vertexShaderScript = [
@@ -167,7 +167,7 @@ H264bsdCanvas.prototype.initProgram = function() {
 /**
  * Initialize vertex buffers and attach to shader program
  */
-H264bsdCanvas.prototype.initBuffers = function() {
+WebGLCanvas.prototype.initBuffers = function() {
     var gl = this.contextGL;
     var program = this.shaderProgram;
 
@@ -193,7 +193,7 @@ H264bsdCanvas.prototype.initBuffers = function() {
 /**
  * Initialize GL textures and attach to shader program
  */
-H264bsdCanvas.prototype.initTextures = function() {
+WebGLCanvas.prototype.initTextures = function() {
     var gl = this.contextGL;
     var program = this.shaderProgram;
 
@@ -216,7 +216,7 @@ H264bsdCanvas.prototype.initTextures = function() {
 /**
  * Create and configure a single texture
  */
-H264bsdCanvas.prototype.initTexture = function() {
+WebGLCanvas.prototype.initTexture = function() {
     var gl = this.contextGL;
 
     var textureRef = gl.createTexture();
@@ -235,7 +235,7 @@ H264bsdCanvas.prototype.initTexture = function() {
  * If this object is using WebGL, the data must be an I420 formatted ArrayBuffer,
  * Otherwise, data must be an RGBA formatted ArrayBuffer.
  */
-H264bsdCanvas.prototype.drawNextOutputPicture = function(width, height, croppingParams, data) {
+WebGLCanvas.prototype.drawNextOutputPicture = function(width, height, croppingParams, data) {
     var gl = this.contextGL;
 
     if(gl) {
@@ -248,7 +248,7 @@ H264bsdCanvas.prototype.drawNextOutputPicture = function(width, height, cropping
 /**
  * Draw the next output picture using WebGL
  */
-H264bsdCanvas.prototype.drawNextOuptutPictureGL = function(width, height, croppingParams, data) {
+WebGLCanvas.prototype.drawNextOuptutPictureGL = function(width, height, croppingParams, data) {
     var gl = this.contextGL;
     var texturePosBuffer = this.texturePosBuffer;
     var yTextureRef = this.yTextureRef;
@@ -296,7 +296,7 @@ H264bsdCanvas.prototype.drawNextOuptutPictureGL = function(width, height, croppi
 /**
  * Draw next output picture using ARGB data on a 2d canvas.
  */
-H264bsdCanvas.prototype.drawNextOuptutPictureRGBA = function(width, height, croppingParams, data) {
+WebGLCanvas.prototype.drawNextOuptutPictureRGBA = function(width, height, croppingParams, data) {
     var canvas = this.canvasElement;
 
     var croppingParams = null;
@@ -314,6 +314,6 @@ H264bsdCanvas.prototype.drawNextOuptutPictureRGBA = function(width, height, crop
     }
 };
   
-  return H264bsdCanvas;
+  return WebGLCanvas;
   
 }));

--- a/Player/WebGLCanvas.js
+++ b/Player/WebGLCanvas.js
@@ -44,11 +44,17 @@
  * This class can be used to render output pictures from a video decoder to a canvas element.
  * If available the content is rendered using WebGL.
  */
-  function WebGLCanvas(canvas, forceNoGL, contextOptions) {
+  function WebGLCanvas(canvas, forceNoGL, contextOptions, conversionType) {
     this.canvasElement = canvas;
     this.contextOptions = contextOptions;
 
     if(!forceNoGL) this.initContextGL();
+
+    if (typeof conversionType !== 'undefined') {
+        this.conversionType = conversionType;
+    } else {
+        this.conversionType = "rec601";
+    }
 
     if(this.contextGL) {
       this.initProgram();
@@ -121,14 +127,7 @@ WebGLCanvas.prototype.initProgram = function() {
         'uniform sampler2D ySampler;',
         'uniform sampler2D uSampler;',
         'uniform sampler2D vSampler;',
-        'const mat4 YUV2RGB = mat4',
-        '(',
-            '1.1643828125, 0, 1.59602734375, -.87078515625,',
-            '1.1643828125, -.39176171875, -.81296875, .52959375,',
-            '1.1643828125, 2.017234375, 0, -1.081390625,',
-            '0, 0, 0, 1',
-        ');',
-      
+        'uniform mat4 YUV2RGB;',
         'void main(void) {',
             'highp float y = texture2D(ySampler,  textureCoord).r;',
             'highp float u = texture2D(uSampler,  textureCoord).r;',
@@ -136,6 +135,26 @@ WebGLCanvas.prototype.initProgram = function() {
             'gl_FragColor = vec4(y, u, v, 1) * YUV2RGB;',
         '}'
         ].join('\n');
+
+    var YUV2RGB = [];
+
+    if (this.conversionType == "rec709") {
+        // ITU-T Rec. 709
+        YUV2RGB = [
+            1.16438, 0.00000,  1.79274,  -0.97295,
+            1.16438, -0.21325, -0.53291,  0.30148,
+            1.16438,  2.11240, 0.00000,  -1.13340,
+            0, 0, 0, 1,
+        ];
+    } else {
+        // assume ITU-T Rec. 601
+        YUV2RGB = [
+            1.1643828125, 0, 1.59602734375, -.87078515625,
+            1.1643828125, -.39176171875, -.81296875, .52959375,
+            1.1643828125, 2.017234375, 0, -1.081390625,
+            0, 0, 0, 1
+        ];
+    }
 
     var vertexShader = gl.createShader(gl.VERTEX_SHADER);
     gl.shaderSource(vertexShader, vertexShaderScript);
@@ -161,6 +180,9 @@ WebGLCanvas.prototype.initProgram = function() {
 
     gl.useProgram(program);
     
+    var YUV2RGBRef = gl.getUniformLocation(program, 'YUV2RGB');
+    gl.uniformMatrix4fv(YUV2RGBRef, false, YUV2RGB);
+
     this.shaderProgram = program;
 };
 


### PR DESCRIPTION
This allows to select the conversion matrix coefficients to adopt ITU-R Rec.709 conversion values.

It is especially useful when combining videos coming from different sources adopting different colorspaces.

I can skip the first cosmetical patch and provide some explanation with regards to the conversion matrix if required.

Thanks.