### PR TITLE
Fallback to mediump precision for device that doesn't support highp

### DIFF
--- a/Player/WebGLCanvas.js
+++ b/Player/WebGLCanvas.js
@@ -136,6 +136,11 @@ H264bsdCanvas.prototype.initProgram = function() {
             'gl_FragColor = vec4(y, u, v, 1) * YUV2RGB;',
         '}'
         ].join('\n');
+    
+    var precisionFormat = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);
+    if(precisionFormat.precision <= 0) {
+        fragmentShaderScript.replace(/highp/g, 'mediump');   
+    }
 
     var vertexShader = gl.createShader(gl.VERTEX_SHADER);
     gl.shaderSource(vertexShader, vertexShaderScript);


### PR DESCRIPTION
Tested on Nexus 7 2012
http://chromium-bugs.chromium.narkive.com/XAitJUY1/issue-245755-in-chromium-webgl-regression-highp-precision-is-not-supported-in-fragment-shader