### PR TITLE
Fix formatting errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,7 +53,7 @@ p.canvas; // the canvas - put it where you want it
 p.decode(<h264 data>);
 ```
 
-##options:  
+## options:  
 
 useWorker true / false  
 decode in a worker thread  
@@ -74,14 +74,14 @@ domNode
 
 refers to the canvas element.  
 
-##methods:  
+## methods:  
 
 decode (<bin>)
 
 feed the decoder with h264 stream data.  
 
 
-#Decoder.js:  
+# Decoder.js:  
 
 ```
 var p = new Decoder({
@@ -93,22 +93,22 @@ p.onPictureDecoded; // override with a callback function
 p.decode(<h264 data>);
 ```
 
-##options:  
+## options:  
 
 rgb true / false  
 if true will convert the image to rgb. sligtly slower.  
 
-##properties:  
+## properties:  
 
 onPictureDecoded  callback function(<bin>, width, height)
 
 will be called for each frame.
 
-##methods:  
+## methods:  
 
 decode (<bin>)
 
 feed the decoder with h264 stream data.  
 
 
-#[Real World Uses of Broadway.js](https://github.com/mbebenita/Broadway/wiki/Real-World-Uses)
+# [Real World Uses of Broadway.js](https://github.com/mbebenita/Broadway/wiki/Real-World-Uses)

--- a/README.markdown
+++ b/README.markdown
@@ -41,7 +41,7 @@ API
 Player.js, Decoder.js and YUVWebGLCanvas.js all have a unified module definition.  
 You can use them as plain js files or with common.js / AMD  
 
-#Player.js:  
+# Player.js:  
 
 ```
 var p = new Player({
@@ -67,7 +67,7 @@ use webgl. defaults to "auto"
 size { width: <num>, height: <num> }  
 initial size of the canvas. canvas will resize after video starts streaming.  
 
-##properties:  
+## properties:  
 
 canvas  
 domNode  


### PR DESCRIPTION
There was no spacing between some titles and their markdown styling characters. All this is doing is adding the necessary spacing in README.markdown

Example:

 ```
##options:
 ```

becomes

 ```
## options:
 ```