### PR TITLE
Responsive (scalable) video output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Andreas Gal <gal@mozilla.com>
 Mathieu 'p01' Henri <mathieu@p01.org>
 Matthias 'soliton4' Behrens <matthias.behrens@gmail.com>
 Sam Leitch @oneam - provided the webgl canvas
+Oliver Jones @OllieJones <olliejones@gmail.com> - Responsive (scalable) output canvas

--- a/Player/Player.js
+++ b/Player/Player.js
@@ -4,9 +4,15 @@
 usage:
 
 p = new Player({
-  useWorker: <bool>,
+  useWorker: true | false | "auto" // defaults to "auto",
   workerFile: <defaults to "Decoder.js"> // give path to Decoder.js
   webgl: true | false | "auto" // defaults to "auto"
+  targetScalable:  true | false // allow target display to be scalable, defaults to false
+  size: {
+            width: targetWidth,
+            height: targetHeight
+  }
+
 });
 
 // canvas property represents the canvas node
@@ -15,108 +21,122 @@ p.canvas;
 
 p.webgl; // contains the used rendering mode. if you pass auto to webgl you can see what auto detection resulted in
 
-p.decode(<binary>);
-
+// We can pass a Javascript timestamp if we have one.
+// The infos
+var infos = {timestamp:ts};
+p.decode(<binary>, infos);  // infos is optional
 
 */
 
-
-
 // universal module definition
-(function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(["./Decoder", "./YUVCanvas"], factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory(require("./Decoder"), require("./YUVCanvas"));
-    } else {
-        // Browser globals (root is window)
-        root.Player = factory(root.Decoder, root.YUVCanvas);
-    }
-}(this, function (Decoder, WebGLCanvas) {
-  "use strict";
-  
-  
+(function(root, factory){
+  if (typeof define === 'function' && define.amd){
+    // AMD. Register as an anonymous module.
+    define(['./Decoder', './YUVCanvas'], factory);
+  }else if (typeof exports === 'object'){
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory(require('./Decoder'), require('./YUVCanvas'));
+  }else{
+    // Browser globals (root is window)
+    root.Player = factory(root.Decoder, root.YUVCanvas);
+  }
+}(this, function(Decoder, WebGLCanvas){
+  'use strict';
+
   var nowValue = Decoder.nowValue;
-  
-  
+
   var Player = function(parOptions){
     var self = this;
     this._config = parOptions || {};
-    
+
     this.render = true;
     if (this._config.render === false){
       this.render = false;
-    };
-    
+    }
+    ;
+
     this.nowValue = nowValue;
-    
-    this._config.workerFile = this._config.workerFile || "Decoder.js";
+
+    this._config.workerFile = this._config.workerFile || 'Decoder.js';
     if (this._config.preserveDrawingBuffer){
       this._config.contextOptions = this._config.contextOptions || {};
       this._config.contextOptions.preserveDrawingBuffer = true;
-    };
-    
-    var webgl = "auto";
-    if (this._config.webgl === true){
-      webgl = true;
-    }else if (this._config.webgl === false){
+    }
+
+    var webglOpt = this._config.webgl;
+    var webgl = false;
+    var haveWebgl = true;
+    try {
+      if (!window.WebGLRenderingContext){
+        /* browser lacks WebGL */
+        haveWebgl = false;
+      }else{
+        var canvas = document.createElement('canvas');
+        var ctx = canvas.getContext('webgl');
+        /* internet explorer 11
+         * cannot handle viewport setting to fix right black bar
+         * || canvas.getContext("experimental-webgl") */
+        if (!ctx){
+          /* browser supports WebGL but initialization failed */
+          haveWebgl = false;
+        }
+      }
+    }
+    catch(e) {
+      haveWebgl = false;
+    }
+    if (haveWebgl && (webglOpt === 'auto' || webglOpt === true)) webgl = true;
+    else if (!haveWebgl && webglOpt === false) webgl = false;
+    else{
+      /* announce inability to honor webgl request, and fall back */
+      console.log('broadway WebGL unavailable');
       webgl = false;
-    };
-    
-    if (webgl == "auto"){
-      webgl = true;
-      try{
-        if (!window.WebGLRenderingContext) {
-          // the browser doesn't even know what WebGL is
-          webgl = false;
-        } else {
-          var canvas = document.createElement('canvas');
-          var ctx = canvas.getContext("webgl");
-          if (!ctx) {
-            // browser supports WebGL but initialization failed.
-            webgl = false;
-          };
-        };
-      }catch(e){
-        webgl = false;
-      };
-    };
-    
+    }
     this.webgl = webgl;
-    
+
     // choose functions
     if (this.webgl){
       this.createCanvasObj = this.createCanvasWebGL;
       this.renderFrame = this.renderFrameWebGL;
-    }else{
+    }
+    else{
       this.createCanvasObj = this.createCanvasRGB;
       this.renderFrame = this.renderFrameRGB;
-    };
-    
-    
+    }
+
     var lastWidth;
     var lastHeight;
-    var onPictureDecoded = function(buffer, width, height, infos) {
-      self.onPictureDecoded(buffer, width, height, infos);
-      
+    var onPictureDecoded = function(buffer, width, height, infosArray){
+
+      self.onPictureDecoded(buffer, width, height, infosArray);
+
       var startTime = nowValue();
-      
-      if (!buffer || !self.render) {
+      var infos = {};
+      if (infosArray && infosArray[0]) infos = infosArray[0];
+      if (!buffer || !self.render){
         return;
-      };
-      
+      }
+
+      infos.sourceWidth = this.sourceWidth || infos.sourceWidth || width;
+      infos.sourceHeight = this.sourceHeight || infos.sourceHeight || height;
+      infos.targetWidth = this.targetWidth || infos.targetWidth || width;
+      infos.targetHeight = this.targetHeight || infos.targetHeight || height;
+      infos.decodedWidth = this.decodedWidth || width;
+      infos.decodedHeight = this.decodedHeight || height;
+      infos.targetScalable = this.targetScalable;
+
+
       self.renderFrame({
         canvasObj: self.canvasObj,
         data: buffer,
         width: width,
-        height: height
+        height: height,
+        infos: infos
       });
-      
-      if (self.onRenderFrameComplete){
+
+      if (self.onRenderFrameComplete && typeof self.onRenderFrameComplete === 'function'){
         self.onRenderFrameComplete({
           data: buffer,
           width: width,
@@ -124,58 +144,63 @@ p.decode(<binary>);
           infos: infos,
           canvasObj: self.canvasObj
         });
-      };
-      
+      }
+
     };
-    
+
     // provide size
-    
-    if (!this._config.size){
-      this._config.size = {};
-    };
-    this._config.size.width = this._config.size.width || 200;
-    this._config.size.height = this._config.size.height || 200;
-    
+    if (!this._config.size) this._config.size = {};
+    this._config.size.width = Math.round(this._config.size.width) || 200;
+    this._config.size.height = Math.round(this._config.size.height) || 200;
+
+    this.targetWidth = this._config.size.width;
+    this.targetHeight = this._config.size.height;
+    this.targetScalable = this._config.targetScalable || false;
+
     if (this._config.useWorker){
       var worker = new Worker(this._config.workerFile);
       this.worker = worker;
-      worker.addEventListener('message', function(e) {
+      worker.addEventListener('message', function(e){
         var data = e.data;
         if (data.consoleLog){
           console.log(data.consoleLog);
           return;
-        };
-        
+        }
         onPictureDecoded.call(self, new Uint8Array(data.buf, 0, data.length), data.width, data.height, data.infos);
-        
       }, false);
-      
-      worker.postMessage({type: "Broadway.js - Worker init", options: {
-        rgb: !webgl,
-        memsize: this.memsize,
-        reuseMemory: this._config.reuseMemory ? true : false
-      }});
-      
+
+      worker.postMessage({
+        type: 'Broadway.js - Worker init', options: {
+          rgb: !webgl,
+          memsize: this.memsize,
+          reuseMemory: this._config.reuseMemory?true:false
+        }
+      });
+
       if (this._config.transferMemory){
         this.decode = function(parData, parInfo){
           // no copy
           // instead we are transfering the ownership of the buffer
           // dangerous!!!
-          
-          worker.postMessage({buf: parData.buffer, offset: parData.byteOffset, length: parData.length, info: parInfo}, [parData.buffer]); // Send data to our worker.
+          worker.postMessage({
+            buf: parData.buffer,
+            offset: parData.byteOffset,
+            length: parData.length,
+            info: parInfo
+          }, [parData.buffer]); // Send data to our worker.
         };
-        
-      }else{
+
+      }
+      else{
         this.decode = function(parData, parInfo){
           // Copy the sample so that we only do a structured clone of the
           // region of interest
           var copyU8 = new Uint8Array(parData.length);
-          copyU8.set( parData, 0, parData.length );
+          copyU8.set(parData, 0, parData.length);
           worker.postMessage({buf: copyU8.buffer, offset: 0, length: parData.length, info: parInfo}, [copyU8.buffer]); // Send data to our worker.
         };
-        
-      };
-      
+      }
+
       if (this._config.reuseMemory){
         this.recycleMemory = function(parArray){
           //this.beforeRecycle();
@@ -183,9 +208,8 @@ p.decode(<binary>);
           //this.afterRecycle();
         };
       }
-      
-    }else{
-      
+    }
+    else{
       this.decoder = new Decoder({
         rgb: !webgl
       });
@@ -194,35 +218,77 @@ p.decode(<binary>);
       this.decode = function(parData, parInfo){
         self.decoder.decode(parData, parInfo);
       };
-      
-    };
-    
-    
-    
+    }
+
+
     if (this.render){
       this.canvasObj = this.createCanvasObj({
         contextOptions: this._config.contextOptions
       });
       this.canvas = this.canvasObj.canvas;
-    };
+    }
+    ;
 
     this.domNode = this.canvas;
-    
+
     lastWidth = this._config.size.width;
     lastHeight = this._config.size.height;
-    
+
   };
-  
+
   Player.prototype = {
-    
-    onPictureDecoded: function(buffer, width, height, infos){},
-    
+
+    /***
+     * The video source can have slightly smaller dimensions than the encoded video stream.
+     * If the user of Player knows them by out-of-band means, give them here.
+     * @param object with width and height members
+     */
+    setSourceDimensions: function(p){
+      this.sourceWidth = Math.round(p.width);
+      this.sourceHeight = Math.round(p.height);
+    },
+
+    /***
+     * Retrieve the dimensions of the video source
+     * (which may be slightly smaller than the decoded dimensions)
+     * @returns {{width: *, height: *}}
+     */
+    getSourceDimensions: function(){
+      return {width: this.sourceWidth, height: this.sourceHeight};
+    },
+
+    /***
+     * when the output is responsive
+     * (when targetScalable is true)
+     * it's possible for the desired size
+     * of the target canvas to change.
+     * call this to change it for subsequent frames.
+     * these values are ignored when targetScalable is false.
+     * @param object with width and height members
+     */
+    setTargetDimensions: function(p){
+      this.targetWidth = Math.round(p.width);
+      this.targetHeight = Math.round(p.height);
+    },
+
+    /***
+     * Retrieve the dimensions of the canvas being drawn.
+     * @returns {{width: *, height: *}}
+     */
+    getTargetDimensions: function(){
+      return {width: this.targetWidth, height: this.targetHeight};
+    },
+
+
+    onPictureDecoded: function(buffer, width, height, infos){
+    },
+
     // call when memory of decoded frames is not used anymore
     recycleMemory: function(buf){
     },
     /*beforeRecycle: function(){},
     afterRecycle: function(){},*/
-    
+
     // for both functions options is:
     //
     //  width
@@ -235,101 +301,202 @@ p.decode(<binary>);
       canvasObj.contextOptions = options.contextOptions;
       return canvasObj;
     },
-    
+
     createCanvasRGB: function(options){
       var canvasObj = this._createBasicCanvasObj(options);
       return canvasObj;
     },
-    
+
     // part that is the same for webGL and RGB
     _createBasicCanvasObj: function(options){
       options = options || {};
-      
+
       var obj = {};
       var width = options.width;
       if (!width){
         width = this._config.size.width;
-      };
+      }
+      ;
       var height = options.height;
       if (!height){
         height = this._config.size.height;
-      };
+      }
+      ;
       obj.canvas = document.createElement('canvas');
       obj.canvas.width = width;
       obj.canvas.height = height;
-      obj.canvas.style.backgroundColor = "#0D0E1B";
-      
-      
+      obj.canvas.style.backgroundColor = this._config.backgroundColor || '#0D0E1B';
+
+
       return obj;
     },
-    
+
     // options:
     //
     // canvas
     // data
     renderFrameWebGL: function(options){
-      
+
       var canvasObj = options.canvasObj;
-      
-      var width = options.width || canvasObj.canvas.width;
-      var height = options.height || canvasObj.canvas.height;
-      
-      if (canvasObj.canvas.width !== width || canvasObj.canvas.height !== height || !canvasObj.webGLCanvas){
-        canvasObj.canvas.width = width;
-        canvasObj.canvas.height = height;
+
+      var decodedWidth = options.width || options.infos.decodedWidth;
+      var decodedHeight = options.height || options.infos.decodedHeight;
+      var newWidth = decodedWidth;
+      var newHeight = decodedHeight;
+
+      if (options.infos.targetScalable){
+        /* when scaling decoded image to target area, adjust dimensions
+         * to preserve decoded aspect ratio
+         */
+        newWidth = options.infos.targetWidth;
+        newHeight = options.infos.targetHeight;
+        var targetAspectRatio = newWidth / newHeight;
+        var decodedAspectRatio = decodedWidth / decodedHeight;
+        if (targetAspectRatio > decodedAspectRatio)
+          newWidth = Math.round(newHeight * decodedAspectRatio);
+        else
+          newHeight = Math.round(newWidth / decodedAspectRatio);
+      }
+      if (!canvasObj.webGLCanvas || canvasObj.canvas.width !== newWidth || canvasObj.canvas.height !== newHeight){
+        /* no canvas yet, or target canvas size changeed */
+        canvasObj.canvas.width = newWidth;
+        canvasObj.canvas.height = newHeight;
         canvasObj.webGLCanvas = new WebGLCanvas({
           canvas: canvasObj.canvas,
           contextOptions: canvasObj.contextOptions,
-          width: width,
-          height: height
+          width: newWidth,
+          height: newHeight,
+          infos: options.infos
         });
-      };
-      
-      var ylen = width * height;
-      var uvlen = (width / 2) * (height / 2);
-      
+        if (this.onFrameSizeChange && typeof this.onFrameSizeChange === 'function'){
+          this.onFrameSizeChange(options.infos);
+        }
+      }
+      var ylen = decodedWidth * decodedHeight;
+      var uvlen = (decodedWidth / 2) * (decodedHeight / 2);
+
       canvasObj.webGLCanvas.drawNextOutputPicture({
         yData: options.data.subarray(0, ylen),
+        yRowCnt: decodedHeight,
+        yDataPerRow: decodedWidth,
         uData: options.data.subarray(ylen, ylen + uvlen),
-        vData: options.data.subarray(ylen + uvlen, ylen + uvlen + uvlen)
+        uRowCnt: decodedHeight / 2,
+        uDataPerRow: decodedWidth / 2,
+        vData: options.data.subarray(ylen + uvlen, ylen + uvlen + uvlen),
+        vRowCnt: decodedHeight / 2,
+        vDataPerRow: decodedWidth / 2,
+        infos: options.infos
       });
-      
+
       var self = this;
       self.recycleMemory(options.data);
-      
+
     },
     renderFrameRGB: function(options){
+
       var canvasObj = options.canvasObj;
 
-      var width = options.width || canvasObj.canvas.width;
-      var height = options.height || canvasObj.canvas.height;
-      
-      if (canvasObj.canvas.width !== width || canvasObj.canvas.height !== height){
-        canvasObj.canvas.width = width;
-        canvasObj.canvas.height = height;
-      };
-      
-      var ctx = canvasObj.ctx;
-      var imgData = canvasObj.imgData;
+      var decodedWidth = options.width || options.infos.decodedWidth;
+      var decodedHeight = options.height || options.infos.decodedHeight;
+      var newWidth = decodedWidth;
+      var newHeight = decodedHeight;
+      var sourceWidth = options.infos.sourceWidth;
+      var sourceHeight = options.infos.sourceHeight;
+      var canvasWidth = canvasObj.canvas.width;
+      var canvasHeight = canvasObj.canvas.height;
+      var targetScalable = options.infos.targetScalable;
+      if (targetScalable){
+        /* when scaling decoded image to target area, adjust dimensions
+         * to preserve decoded aspect ratio
+         */
+        newWidth = options.infos.targetWidth;
+        newHeight = options.infos.targetHeight;
+        var targetAspectRatio = newWidth / newHeight;
+        var decodedAspectRatio = decodedWidth / decodedHeight;
+        if (targetAspectRatio > decodedAspectRatio)
+          newWidth = Math.trunc(newHeight * decodedAspectRatio);
+        else
+          newHeight = Math.trunc(newWidth / decodedAspectRatio);
+      }
+      else if (sourceWidth !== decodedWidth || sourceHeight !== decodedHeight){
+        newWidth = sourceWidth;
+        newHeight = decodedHeight;
+      }
+      if (canvasWidth !== newWidth || canvasHeight !== newHeight){
+        /* target canvas size changeed */
+        options.infos.targetWidth = canvasWidth = canvasObj.canvas.width = newWidth;
+        options.infos.targetHeight = canvasHeight = canvasObj.canvas.height = newHeight;
+        if (this.onFrameSizeChange && typeof this.onFrameSizeChange === 'function'){
+          this.onFrameSizeChange(options.infos);
+        }
+      }
+      /* three rendering cases: identity, clip only, scale and clip */
+      var renderIdentity =
+        decodedWidth === canvasWidth && decodedWidth === sourceWidth &&
+        decodedHeight === canvasHeight && decodedHeight === sourceHeight;
+      var renderClip = (!targetScalable &&
+        (decodedWidth !== sourceWidth) || decodedHeight !== sourceHeight) &&
+        (decodedWidth === canvasWidth) && decodedHeight === canvasHeight;
+      if (renderIdentity){
+        /* fastest */
+        if (!canvasObj.ctx){
+          canvasObj.ctx = canvasObj.canvas.getContext('2d');
+          canvasObj.imgData = canvasObj.ctx.createImageData(width, height);
+        }
+        canvasObj.imgData.data.set(options.data);
+        canvasObj.ctx.putImageData(imgData, 0, 0);
+      }
+      else{
+        var decodedCanvasObj = this.decodedCanvasObj;
+        if (!decodedCanvasObj){
+          decodedCanvasObj = this.decodedCanvasObj = {};
+          decodedCanvasObj.canvas = document.createElement('canvas');
+        }
+        if (decodedCanvasObj.canvas.width !== decodedWidth || decodedCanvasObj.canvas.height !== decodedHeight){
+          decodedCanvasObj.canvas.width = decodedWidth;
+          decodedCanvasObj.canvas.height = decodedHeight;
+        }
+        var decodedCtx = decodedCanvasObj.ctx;
+        var decodedImgData = decodedCanvasObj.imgData;
+        if (!decodedCtx){
+          decodedCanvasObj.ctx = decodedCtx = decodedCanvasObj.canvas.getContext('2d');
+          decodedCanvasObj.imgData = decodedImgData = decodedCtx.createImageData(decodedWidth, decodedHeight);
+        }
+        var targetCtx = canvasObj.ctx;
+        if (!targetCtx){
+          canvasObj.ctx = targetCtx = canvasObj.canvas.getContext('2d');
+        }
 
-      if (!ctx){
-        canvasObj.ctx = canvasObj.canvas.getContext('2d');
-        ctx = canvasObj.ctx;
+        decodedImgData.data.set(options.data);
+        decodedCtx.putImageData(decodedImgData, 0, 0);
 
-        canvasObj.imgData = ctx.createImageData(width, height);
-        imgData = canvasObj.imgData;
-      };
-
-      imgData.data.set(options.data);
-      ctx.putImageData(imgData, 0, 0);
+        if (renderClip){
+          /* just trim black bars from right and bottom */
+          targetCtx.putImageData(decodedCtx.getImageData(0, 0, sourceWidth, sourceHeight), 0, 0);
+        }
+        else{
+          /* scale */
+          var sw = sourceWidth;
+          if (sw !== decodedWidth) sw -= 1;
+          targetCtx.drawImage(decodedCanvasObj.canvas,
+            0, 0, sw, sourceHeight,
+            0, 0, canvasObj.canvas.width, canvasObj.canvas.height);
+        }
+      }
       var self = this;
       self.recycleMemory(options.data);
-      
     }
-    
   };
-  
+  /* polyfill for IE 11 */
+  if (!Math.trunc){
+    Math.trunc = function(v){
+      v = +v;
+      if (!isFinite(v)) return v;
+      return (v - v % 1) || (v < 0?-0:v === 0?v:0);
+    };
+  }
+
   return Player;
-  
+
 }));
 

--- a/Player/YUVCanvas.js
+++ b/Player/YUVCanvas.js
@@ -22,88 +22,102 @@
 
 
 // universal module definition
-(function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define([], factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory();
-    } else {
-        // Browser globals (root is window)
-        root.YUVCanvas = factory();
-    }
-}(this, function () {
+(function(root, factory){
+  if (typeof define === 'function' && define.amd){
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  }else if (typeof exports === 'object'){
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  }else{
+    // Browser globals (root is window)
+    root.YUVCanvas = factory();
+  }
+}(this, function(){
 
 
-/**
- * This class can be used to render output pictures from an H264bsdDecoder to a canvas element.
- * If available the content is rendered using WebGL.
- */
-  function YUVCanvas(parOptions) {
-    
+  /**
+   * This class can be used to render output pictures from an H264bsdDecoder to a canvas element.
+   * If available the content is rendered using WebGL.
+   */
+  function YUVCanvas(parOptions){
+
     parOptions = parOptions || {};
-    
-    this.canvasElement = parOptions.canvas || document.createElement("canvas");
+
+    this.canvasElement = parOptions.canvas || document.createElement('canvas');
     this.contextOptions = parOptions.contextOptions;
-    
-    this.type = parOptions.type || "yuv420";
-    
+
+    this.type = parOptions.type || 'yuv420';
+
     this.customYUV444 = parOptions.customYUV444;
-    
-    this.conversionType = parOptions.conversionType || "rec601";
+
+    this.conversionType = parOptions.conversionType || 'rec601';
 
     this.width = parOptions.width || 640;
     this.height = parOptions.height || 320;
-    
+
     this.animationTime = parOptions.animationTime || 0;
-    
+
     this.canvasElement.width = this.width;
     this.canvasElement.height = this.height;
 
     this.initContextGL();
 
-    if(this.contextGL) {
+    if (this.contextGL){
       this.initProgram();
       this.initBuffers();
       this.initTextures();
-    };
-    
+    }
 
-/**
- * Draw the next output picture using WebGL
- */
+    /**
+     * Draw the next output picture using WebGL
+     */
     if (this.type === "yuv420"){
-      this.drawNextOuptutPictureGL = function(par) {
+      this.drawNextOuptutPictureGL = function(par){
         var gl = this.contextGL;
         var texturePosBuffer = this.texturePosBuffer;
         var uTexturePosBuffer = this.uTexturePosBuffer;
         var vTexturePosBuffer = this.vTexturePosBuffer;
-        
+
         var yTextureRef = this.yTextureRef;
         var uTextureRef = this.uTextureRef;
         var vTextureRef = this.vTextureRef;
-        
-        var yData = par.yData;
-        var uData = par.uData;
-        var vData = par.vData;
-        
-        var width = this.width;
-        var height = this.height;
-        
-        var yDataPerRow = par.yDataPerRow || width;
-        var yRowCnt     = par.yRowCnt || height;
-        
-        var uDataPerRow = par.uDataPerRow || (width / 2);
-        var uRowCnt     = par.uRowCnt || (height / 2);
-        
-        var vDataPerRow = par.vDataPerRow || uDataPerRow;
-        var vRowCnt     = par.vRowCnt || uRowCnt;
-        
-        gl.viewport(0, 0, width, height);
 
+        var width = par.infos.decodedWidth || this.width;
+        var height = par.infos.decodedHeight || this.height;
+
+        var yData = par.yData;
+        var yDataPerRow = par.yDataPerRow || width;
+        var yRowCnt = par.yRowCnt || par.infos.decodedHeight || height;
+        var uData = par.uData;
+        var uDataPerRow = par.uDataPerRow || width / 2;
+        var uRowCnt = par.uRowCnt || (yRowCnt / 2);
+        var vData = par.vData;
+        var vDataPerRow = par.vDataPerRow || uDataPerRow;
+        var vRowCnt = par.vRowCnt || uRowCnt;
+
+
+        /* Adjust the viewport to conceal decoded black bars
+         * when the video source is not an integral
+         * number of 16x16 macroblocks in width, height, or both.
+         * In this case the source width and height come to us
+         * via setSourceDimensions.
+         * Rounding up the row offset to divisible by 8 corrects a right sliver.
+         */
+        var sw = par.infos.sourceWidth;
+        var dw = par.infos.decodedWidth - sw;
+        dw = (dw + 7) - ((dw + 7) % 8);
+        var dh = par.infos.decodedHeight - par.infos.sourceHeight;
+        if (par.infos.targetScalable){
+          var dw = 1 + Math.round(dw * this.width / par.infos.decodedWidth);
+          var dh = Math.round(dh * this.height / par.infos.decodedHeight);
+        }
+        var r = this.width + dw;
+        var t = -dh;
+        var b = this.height + dh;
+        gl.viewport(0, t, r, b);
         var tTop = 0;
         var tLeft = 0;
         var tBottom = height / yRowCnt;
@@ -112,32 +126,31 @@
 
         gl.bindBuffer(gl.ARRAY_BUFFER, texturePosBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, texturePosValues, gl.DYNAMIC_DRAW);
-        
+
+        /* not used in Broadway */
         if (this.customYUV444){
           tBottom = height / uRowCnt;
           tRight = width / uDataPerRow;
         }else{
           tBottom = (height / 2) / uRowCnt;
           tRight = (width / 2) / uDataPerRow;
-        };
+        }
         var uTexturePosValues = new Float32Array([tRight, tTop, tLeft, tTop, tRight, tBottom, tLeft, tBottom]);
 
         gl.bindBuffer(gl.ARRAY_BUFFER, uTexturePosBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, uTexturePosValues, gl.DYNAMIC_DRAW);
-        
-        
+
         if (this.customYUV444){
           tBottom = height / vRowCnt;
           tRight = width / vDataPerRow;
         }else{
           tBottom = (height / 2) / vRowCnt;
           tRight = (width / 2) / vDataPerRow;
-        };
+        }
         var vTexturePosValues = new Float32Array([tRight, tTop, tLeft, tTop, tRight, tBottom, tLeft, tBottom]);
 
         gl.bindBuffer(gl.ARRAY_BUFFER, vTexturePosBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, vTexturePosValues, gl.DYNAMIC_DRAW);
-        
 
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, yTextureRef);
@@ -151,23 +164,25 @@
         gl.bindTexture(gl.TEXTURE_2D, vTextureRef);
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.LUMINANCE, vDataPerRow, vRowCnt, 0, gl.LUMINANCE, gl.UNSIGNED_BYTE, vData);
 
-        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4); 
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
       };
-      
-    }else if (this.type === "yuv422"){
-      this.drawNextOuptutPictureGL = function(par) {
+
+    }
+    /* not used in Broadway */
+    else if (this.type === "yuv422"){
+      this.drawNextOuptutPictureGL = function(par){
         var gl = this.contextGL;
         var texturePosBuffer = this.texturePosBuffer;
-        
+
         var textureRef = this.textureRef;
-        
+
         var data = par.data;
-        
+
         var width = this.width;
         var height = this.height;
-        
+
         var dataPerRow = par.dataPerRow || (width * 2);
-        var rowCnt     = par.rowCnt || height;
+        var rowCnt = par.rowCnt || height;
 
         gl.viewport(0, 0, width, height);
 
@@ -179,37 +194,36 @@
 
         gl.bindBuffer(gl.ARRAY_BUFFER, texturePosBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, texturePosValues, gl.DYNAMIC_DRAW);
-        
+
         gl.uniform2f(gl.getUniformLocation(this.shaderProgram, 'resolution'), dataPerRow, height);
-        
+
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, textureRef);
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.LUMINANCE, dataPerRow, rowCnt, 0, gl.LUMINANCE, gl.UNSIGNED_BYTE, data);
 
-        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4); 
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
       };
-    };
-    
-  };
+    }
+  }
 
   /**
- * Returns true if the canvas supports WebGL
- */
-  YUVCanvas.prototype.isWebGL = function() {
+   * Returns true if the canvas supports WebGL
+   */
+  YUVCanvas.prototype.isWebGL = function(){
     return this.contextGL;
   };
 
   /**
- * Create the GL context from the canvas element
- */
-  YUVCanvas.prototype.initContextGL = function() {
+   * Create the GL context from the canvas element
+   */
+  YUVCanvas.prototype.initContextGL = function(){
     var canvas = this.canvasElement;
     var gl = null;
 
     var validContextNames = ["webgl", "experimental-webgl", "moz-webgl", "webkit-3d"];
     var nameIndex = 0;
 
-    while(!gl && nameIndex < validContextNames.length) {
+    while(!gl && nameIndex < validContextNames.length){
       var contextName = validContextNames[nameIndex];
 
       try {
@@ -217,110 +231,109 @@
           gl = canvas.getContext(contextName, this.contextOptions);
         }else{
           gl = canvas.getContext(contextName);
-        };
-      } catch (e) {
+        }
+      } catch(e) {
         gl = null;
       }
 
-      if(!gl || typeof gl.getParameter !== "function") {
+      if(!gl || typeof gl.getParameter !== "function"){
         gl = null;
-      }    
+      }
 
       ++nameIndex;
-    };
+    }
 
     this.contextGL = gl;
   };
 
-/**
- * Initialize GL shader program
- */
-YUVCanvas.prototype.initProgram = function() {
+  /**
+   * Initialize GL shader program
+   */
+  YUVCanvas.prototype.initProgram = function(){
     var gl = this.contextGL;
 
-  // vertex shader is the same for all types
-  var vertexShaderScript;
-  var fragmentShaderScript;
-  
-  if (this.type === "yuv420"){
+    // vertex shader is the same for all types
+    var vertexShaderScript;
+    var fragmentShaderScript;
 
-    vertexShaderScript = [
-      'attribute vec4 vertexPos;',
-      'attribute vec4 texturePos;',
-      'attribute vec4 uTexturePos;',
-      'attribute vec4 vTexturePos;',
-      'varying vec2 textureCoord;',
-      'varying vec2 uTextureCoord;',
-      'varying vec2 vTextureCoord;',
+    if (this.type === "yuv420"){
 
-      'void main()',
-      '{',
-      '  gl_Position = vertexPos;',
-      '  textureCoord = texturePos.xy;',
-      '  uTextureCoord = uTexturePos.xy;',
-      '  vTextureCoord = vTexturePos.xy;',
-      '}'
-    ].join('\n');
-    
-    fragmentShaderScript = [
-      'precision highp float;',
-      'varying highp vec2 textureCoord;',
-      'varying highp vec2 uTextureCoord;',
-      'varying highp vec2 vTextureCoord;',
-      'uniform sampler2D ySampler;',
-      'uniform sampler2D uSampler;',
-      'uniform sampler2D vSampler;',
-      'uniform mat4 YUV2RGB;',
+      vertexShaderScript = [
+        'attribute vec4 vertexPos;',
+        'attribute vec4 texturePos;',
+        'attribute vec4 uTexturePos;',
+        'attribute vec4 vTexturePos;',
+        'varying vec2 textureCoord;',
+        'varying vec2 uTextureCoord;',
+        'varying vec2 vTextureCoord;',
 
-      'void main(void) {',
-      '  highp float y = texture2D(ySampler,  textureCoord).r;',
-      '  highp float u = texture2D(uSampler,  uTextureCoord).r;',
-      '  highp float v = texture2D(vSampler,  vTextureCoord).r;',
-      '  gl_FragColor = vec4(y, u, v, 1) * YUV2RGB;',
-      '}'
-    ].join('\n');
-    
-  }else if (this.type === "yuv422"){
-    vertexShaderScript = [
-      'attribute vec4 vertexPos;',
-      'attribute vec4 texturePos;',
-      'varying vec2 textureCoord;',
+        'void main()',
+        '{',
+        '  gl_Position = vertexPos;',
+        '  textureCoord = texturePos.xy;',
+        '  uTextureCoord = uTexturePos.xy;',
+        '  vTextureCoord = vTexturePos.xy;',
+        '}'
+      ].join('\n');
 
-      'void main()',
-      '{',
-      '  gl_Position = vertexPos;',
-      '  textureCoord = texturePos.xy;',
-      '}'
-    ].join('\n');
-    
-    fragmentShaderScript = [
-      'precision highp float;',
-      'varying highp vec2 textureCoord;',
-      'uniform sampler2D sampler;',
-      'uniform highp vec2 resolution;',
-      'uniform mat4 YUV2RGB;',
+      fragmentShaderScript = [
+        'precision highp float;',
+        'varying highp vec2 textureCoord;',
+        'varying highp vec2 uTextureCoord;',
+        'varying highp vec2 vTextureCoord;',
+        'uniform sampler2D ySampler;',
+        'uniform sampler2D uSampler;',
+        'uniform sampler2D vSampler;',
+        'uniform mat4 YUV2RGB;',
 
-      'void main(void) {',
-      
-      '  highp float texPixX = 1.0 / resolution.x;',
-      '  highp float logPixX = 2.0 / resolution.x;', // half the resolution of the texture
-      '  highp float logHalfPixX = 4.0 / resolution.x;', // half of the logical resolution so every 4th pixel
-      '  highp float steps = floor(textureCoord.x / logPixX);',
-      '  highp float uvSteps = floor(textureCoord.x / logHalfPixX);',
-      '  highp float y = texture2D(sampler, vec2((logPixX * steps) + texPixX, textureCoord.y)).r;',
-      '  highp float u = texture2D(sampler, vec2((logHalfPixX * uvSteps), textureCoord.y)).r;',
-      '  highp float v = texture2D(sampler, vec2((logHalfPixX * uvSteps) + texPixX + texPixX, textureCoord.y)).r;',
-      
-      //'  highp float y = texture2D(sampler,  textureCoord).r;',
-      //'  gl_FragColor = vec4(y, u, v, 1) * YUV2RGB;',
-      '  gl_FragColor = vec4(y, u, v, 1.0) * YUV2RGB;',
-      '}'
-    ].join('\n');
-  };
+        'void main(void) {',
+        '  highp float y = texture2D(ySampler,  textureCoord).r;',
+        '  highp float u = texture2D(uSampler,  uTextureCoord).r;',
+        '  highp float v = texture2D(vSampler,  vTextureCoord).r;',
+        '  gl_FragColor = vec4(y, u, v, 1) * YUV2RGB;',
+        '}'
+      ].join('\n');
 
-  var YUV2RGB = [];
+    }else if (this.type === 'yuv422'){
+      vertexShaderScript = [
+        'attribute vec4 vertexPos;',
+        'attribute vec4 texturePos;',
+        'varying vec2 textureCoord;',
 
-  if (this.conversionType == "rec709") {
+        'void main()',
+        '{',
+        '  gl_Position = vertexPos;',
+        '  textureCoord = texturePos.xy;',
+        '}'
+      ].join('\n');
+
+      fragmentShaderScript = [
+        'precision highp float;',
+        'varying highp vec2 textureCoord;',
+        'uniform sampler2D sampler;',
+        'uniform highp vec2 resolution;',
+        'uniform mat4 YUV2RGB;',
+
+        'void main(void) {',
+
+        '  highp float texPixX = 1.0 / resolution.x;',
+        '  highp float logPixX = 2.0 / resolution.x;', // half the resolution of the texture
+        '  highp float logHalfPixX = 4.0 / resolution.x;', // half of the logical resolution so every 4th pixel
+        '  highp float steps = floor(textureCoord.x / logPixX);',
+        '  highp float uvSteps = floor(textureCoord.x / logHalfPixX);',
+        '  highp float y = texture2D(sampler, vec2((logPixX * steps) + texPixX, textureCoord.y)).r;',
+        '  highp float u = texture2D(sampler, vec2((logHalfPixX * uvSteps), textureCoord.y)).r;',
+        '  highp float v = texture2D(sampler, vec2((logHalfPixX * uvSteps) + texPixX + texPixX, textureCoord.y)).r;',
+
+        //'  highp float y = texture2D(sampler,  textureCoord).r;',
+        //'  gl_FragColor = vec4(y, u, v, 1) * YUV2RGB;',
+        '  gl_FragColor = vec4(y, u, v, 1.0) * YUV2RGB;',
+        '}'
+      ].join('\n');
+    }
+    var YUV2RGB = [];
+
+    if (this.conversionType == "rec709") {
       // ITU-T Rec. 709
       YUV2RGB = [
           1.16438,  0.00000,  1.79274, -0.97295,
@@ -336,165 +349,167 @@ YUVCanvas.prototype.initProgram = function() {
           1.16438,  2.01723,  0.00000, -1.08139,
           0, 0, 0, 1
       ];
+    }
+    var vertexShader = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vertexShader, vertexShaderScript);
+    gl.compileShader(vertexShader);
+    if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)){
+      console.log('Vertex shader failed to compile: ' + gl.getShaderInfoLog(vertexShader));
+    }
+
+    var fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fragmentShader, fragmentShaderScript);
+    gl.compileShader(fragmentShader);
+    if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)){
+      console.log('Fragment shader failed to compile: ' + gl.getShaderInfoLog(fragmentShader));
+    }
+
+    var program = gl.createProgram();
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)){
+      console.log('Program failed to compile: ' + gl.getProgramInfoLog(program));
+    }
+
+    gl.useProgram(program);
+
+    var YUV2RGBRef = gl.getUniformLocation(program, 'YUV2RGB');
+    gl.uniformMatrix4fv(YUV2RGBRef, false, YUV2RGB);
+
+    this.shaderProgram = program;
   };
 
-  var vertexShader = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vertexShader, vertexShaderScript);
-  gl.compileShader(vertexShader);
-  if(!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
-    console.log('Vertex shader failed to compile: ' + gl.getShaderInfoLog(vertexShader));
-  }
+  /**
+   * Initialize vertex buffers and attach to shader program
+   */
+  YUVCanvas.prototype.initBuffers = function(){
+    var gl = this.contextGL;
+    var program = this.shaderProgram;
 
-  var fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fragmentShader, fragmentShaderScript);
-  gl.compileShader(fragmentShader);
-  if(!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
-    console.log('Fragment shader failed to compile: ' + gl.getShaderInfoLog(fragmentShader));
-  }
+    /* This is a two-triangle TRIANGLE_STRIP object
+     * spanning the rectangle (-1,-1) -  (1,1).
+     * Each frame of video redraws this rectangle, scaled into
+     * the size and aspect ratio of the video, with a
+     * different set of textures. The textures are made
+     * from the decoded video.
+     */
+    var vertexPosBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexPosBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 1, -1, 1, 1, -1, -1, -1]), gl.STATIC_DRAW);
 
-  var program = gl.createProgram();
-  gl.attachShader(program, vertexShader);
-  gl.attachShader(program, fragmentShader);
-  gl.linkProgram(program);
-  if(!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-    console.log('Program failed to compile: ' + gl.getProgramInfoLog(program));
-  }
+    var vertexPosRef = gl.getAttribLocation(program, 'vertexPos');
+    gl.enableVertexAttribArray(vertexPosRef);
+    gl.vertexAttribPointer(vertexPosRef, 2, gl.FLOAT, false, 0, 0);
 
-  gl.useProgram(program);
+    if (this.animationTime){
 
-  var YUV2RGBRef = gl.getUniformLocation(program, 'YUV2RGB');
-  gl.uniformMatrix4fv(YUV2RGBRef, false, YUV2RGB);
+      var animationTime = this.animationTime;
+      var timePassed = 0;
+      var stepTime = 15;
 
-  this.shaderProgram = program;
-};
+      var aniFun = function(){
 
-/**
- * Initialize vertex buffers and attach to shader program
- */
-YUVCanvas.prototype.initBuffers = function() {
-  var gl = this.contextGL;
-  var program = this.shaderProgram;
+        timePassed += stepTime;
+        var mul = (1 * timePassed) / animationTime;
 
-  var vertexPosBuffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, vertexPosBuffer);
-  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 1, -1, 1, 1, -1, -1, -1]), gl.STATIC_DRAW);
+        if (timePassed >= animationTime){
+          mul = 1;
+        }else{
+          setTimeout(aniFun, stepTime);
+        }
+        var neg = -1 * mul;
+        var pos = 1 * mul;
 
-  var vertexPosRef = gl.getAttribLocation(program, 'vertexPos');
-  gl.enableVertexAttribArray(vertexPosRef);
-  gl.vertexAttribPointer(vertexPosRef, 2, gl.FLOAT, false, 0, 0);
-  
-  if (this.animationTime){
-    
-    var animationTime = this.animationTime;
-    var timePassed = 0;
-    var stepTime = 15;
-  
-    var aniFun = function(){
-      
-      timePassed += stepTime;
-      var mul = ( 1 * timePassed ) / animationTime;
-      
-      if (timePassed >= animationTime){
-        mul = 1;
-      }else{
-        setTimeout(aniFun, stepTime);
+        var vertexPosBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexPosBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([pos, pos, neg, pos, pos, neg, neg, neg]), gl.STATIC_DRAW);
+
+        var vertexPosRef = gl.getAttribLocation(program, 'vertexPos');
+        gl.enableVertexAttribArray(vertexPosRef);
+        gl.vertexAttribPointer(vertexPosRef, 2, gl.FLOAT, false, 0, 0);
+
+        try {
+          gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+        } catch(e) {
+        }
+
       };
-      
-      var neg = -1 * mul;
-      var pos = 1 * mul;
+      aniFun();
 
-      var vertexPosBuffer = gl.createBuffer();
-      gl.bindBuffer(gl.ARRAY_BUFFER, vertexPosBuffer);
-      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([pos, pos, neg, pos, pos, neg, neg, neg]), gl.STATIC_DRAW);
-
-      var vertexPosRef = gl.getAttribLocation(program, 'vertexPos');
-      gl.enableVertexAttribArray(vertexPosRef);
-      gl.vertexAttribPointer(vertexPosRef, 2, gl.FLOAT, false, 0, 0);
-      
-      try{
-        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
-      }catch(e){};
-
-    };
-    aniFun();
-    
-  };
-
-  
-
-  var texturePosBuffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, texturePosBuffer);
-  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 0, 0, 0, 1, 1, 0, 1]), gl.STATIC_DRAW);
-
-  var texturePosRef = gl.getAttribLocation(program, 'texturePos');
-  gl.enableVertexAttribArray(texturePosRef);
-  gl.vertexAttribPointer(texturePosRef, 2, gl.FLOAT, false, 0, 0);
-
-  this.texturePosBuffer = texturePosBuffer;
-
-  if (this.type === "yuv420"){
-    var uTexturePosBuffer = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, uTexturePosBuffer);
+    }
+    var texturePosBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, texturePosBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 0, 0, 0, 1, 1, 0, 1]), gl.STATIC_DRAW);
 
-    var uTexturePosRef = gl.getAttribLocation(program, 'uTexturePos');
-    gl.enableVertexAttribArray(uTexturePosRef);
-    gl.vertexAttribPointer(uTexturePosRef, 2, gl.FLOAT, false, 0, 0);
+    var texturePosRef = gl.getAttribLocation(program, 'texturePos');
+    gl.enableVertexAttribArray(texturePosRef);
+    gl.vertexAttribPointer(texturePosRef, 2, gl.FLOAT, false, 0, 0);
 
-    this.uTexturePosBuffer = uTexturePosBuffer;
-    
-    
-    var vTexturePosBuffer = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, vTexturePosBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 0, 0, 0, 1, 1, 0, 1]), gl.STATIC_DRAW);
+    this.texturePosBuffer = texturePosBuffer;
 
-    var vTexturePosRef = gl.getAttribLocation(program, 'vTexturePos');
-    gl.enableVertexAttribArray(vTexturePosRef);
-    gl.vertexAttribPointer(vTexturePosRef, 2, gl.FLOAT, false, 0, 0);
+    if (this.type === 'yuv420'){
+      var uTexturePosBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, uTexturePosBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 0, 0, 0, 1, 1, 0, 1]), gl.STATIC_DRAW);
 
-    this.vTexturePosBuffer = vTexturePosBuffer;
+      var uTexturePosRef = gl.getAttribLocation(program, 'uTexturePos');
+      gl.enableVertexAttribArray(uTexturePosRef);
+      gl.vertexAttribPointer(uTexturePosRef, 2, gl.FLOAT, false, 0, 0);
+
+      this.uTexturePosBuffer = uTexturePosBuffer;
+
+
+      var vTexturePosBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, vTexturePosBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 0, 0, 0, 1, 1, 0, 1]), gl.STATIC_DRAW);
+
+      var vTexturePosRef = gl.getAttribLocation(program, 'vTexturePos');
+      gl.enableVertexAttribArray(vTexturePosRef);
+      gl.vertexAttribPointer(vTexturePosRef, 2, gl.FLOAT, false, 0, 0);
+
+      this.vTexturePosBuffer = vTexturePosBuffer;
+    }
   };
 
-};
-
-/**
- * Initialize GL textures and attach to shader program
- */
-YUVCanvas.prototype.initTextures = function() {
-  var gl = this.contextGL;
-  var program = this.shaderProgram;
+  /**
+   * Initialize GL textures and attach to shader program
+   */
+  YUVCanvas.prototype.initTextures = function(){
+    var gl = this.contextGL;
+    var program = this.shaderProgram;
 
   if (this.type === "yuv420"){
 
-    var yTextureRef = this.initTexture();
-    var ySamplerRef = gl.getUniformLocation(program, 'ySampler');
-    gl.uniform1i(ySamplerRef, 0);
-    this.yTextureRef = yTextureRef;
+      var yTextureRef = this.initTexture();
+      var ySamplerRef = gl.getUniformLocation(program, 'ySampler');
+      gl.uniform1i(ySamplerRef, 0);
+      this.yTextureRef = yTextureRef;
 
-    var uTextureRef = this.initTexture();
-    var uSamplerRef = gl.getUniformLocation(program, 'uSampler');
-    gl.uniform1i(uSamplerRef, 1);
-    this.uTextureRef = uTextureRef;
+      var uTextureRef = this.initTexture();
+      var uSamplerRef = gl.getUniformLocation(program, 'uSampler');
+      gl.uniform1i(uSamplerRef, 1);
+      this.uTextureRef = uTextureRef;
 
-    var vTextureRef = this.initTexture();
-    var vSamplerRef = gl.getUniformLocation(program, 'vSampler');
-    gl.uniform1i(vSamplerRef, 2);
-    this.vTextureRef = vTextureRef;
-    
-  }else if (this.type === "yuv422"){
-    // only one texture for 422
-    var textureRef = this.initTexture();
-    var samplerRef = gl.getUniformLocation(program, 'sampler');
-    gl.uniform1i(samplerRef, 0);
-    this.textureRef = textureRef;
+      var vTextureRef = this.initTexture();
+      var vSamplerRef = gl.getUniformLocation(program, 'vSampler');
+      gl.uniform1i(vSamplerRef, 2);
+      this.vTextureRef = vTextureRef;
 
+    }else if (this.type === "yuv422"){
+      // only one texture for 422  (not used in Broadway)
+      var textureRef = this.initTexture();
+      var samplerRef = gl.getUniformLocation(program, 'sampler');
+      gl.uniform1i(samplerRef, 0);
+      this.textureRef = textureRef;
+
+    }
   };
-};
 
-/**
- * Create and configure a single texture
- */
-YUVCanvas.prototype.initTexture = function() {
+  /**
+   * Create and configure a single texture
+   */
+  YUVCanvas.prototype.initTexture = function(){
     var gl = this.contextGL;
 
     var textureRef = gl.createTexture();
@@ -506,29 +521,28 @@ YUVCanvas.prototype.initTexture = function() {
     gl.bindTexture(gl.TEXTURE_2D, null);
 
     return textureRef;
-};
+  };
 
-/**
- * Draw picture data to the canvas.
- * If this object is using WebGL, the data must be an I420 formatted ArrayBuffer,
- * Otherwise, data must be an RGBA formatted ArrayBuffer.
- */
-YUVCanvas.prototype.drawNextOutputPicture = function(width, height, croppingParams, data) {
+  /**
+   * Draw picture data to the canvas.
+   * If this object is using WebGL, the data must be an I420 formatted ArrayBuffer,
+   * Otherwise, data must be an RGBA formatted ArrayBuffer.
+   */
+  YUVCanvas.prototype.drawNextOutputPicture = function(width, height, croppingParams, data){
     var gl = this.contextGL;
 
-    if(gl) {
-        this.drawNextOuptutPictureGL(width, height, croppingParams, data);
-    } else {
-        this.drawNextOuptutPictureRGBA(width, height, croppingParams, data);
+    if (gl){
+      this.drawNextOuptutPictureGL(width, height, croppingParams, data);
+    }else{
+      this.drawNextOuptutPictureRGBA(width, height, croppingParams, data);
     }
-};
+  };
 
 
-
-/**
- * Draw next output picture using ARGB data on a 2d canvas.
- */
-YUVCanvas.prototype.drawNextOuptutPictureRGBA = function(width, height, croppingParams, data) {
+  /**
+   * Draw next output picture using ARGB data on a 2d canvas. (unused in Broadway)
+   */
+  YUVCanvas.prototype.drawNextOuptutPictureRGBA = function(width, height, croppingParams, data){
     var canvas = this.canvasElement;
 
     var croppingParams = null;
@@ -539,13 +553,13 @@ YUVCanvas.prototype.drawNextOuptutPictureRGBA = function(width, height, cropping
     var imageData = ctx.getImageData(0, 0, width, height);
     imageData.data.set(argbData);
 
-    if(croppingParams === null) {
-        ctx.putImageData(imageData, 0, 0);
-    } else {
-        ctx.putImageData(imageData, -croppingParams.left, -croppingParams.top, 0, 0, croppingParams.width, croppingParams.height);
+    if (croppingParams === null){
+      ctx.putImageData(imageData, 0, 0);
+    }else{
+      ctx.putImageData(imageData, -croppingParams.left, -croppingParams.top, 0, 0, croppingParams.width, croppingParams.height);
     }
-};
-  
+  };
+
   return YUVCanvas;
-  
+
 }));

--- a/Player/YUVCanvas.js
+++ b/Player/YUVCanvas.js
@@ -336,18 +336,18 @@
     if (this.conversionType == "rec709") {
       // ITU-T Rec. 709
       YUV2RGB = [
-          1.16438,  0.00000,  1.79274, -0.97295,
-          1.16438, -0.21325, -0.53291,  0.30148,
-          1.16438,  2.11240,  0.00000, -1.13340,
-          0, 0, 0, 1,
+        1.16438,  0.00000,  1.79274, -0.97295,
+        1.16438, -0.21325, -0.53291,  0.30148,
+        1.16438,  2.11240,  0.00000, -1.13340,
+        0, 0, 0, 1,
       ];
-  } else {
+    } else {
       // assume ITU-T Rec. 601
       YUV2RGB = [
-          1.16438,  0.00000,  1.59603, -0.87079,
-          1.16438, -0.39176, -0.81297,  0.52959,
-          1.16438,  2.01723,  0.00000, -1.08139,
-          0, 0, 0, 1
+        1.16438,  0.00000,  1.59603, -0.87079,
+        1.16438, -0.39176, -0.81297,  0.52959,
+        1.16438,  2.01723,  0.00000, -1.08139,
+        0, 0, 0, 1
       ];
     }
     var vertexShader = gl.createShader(gl.VERTEX_SHADER);
@@ -479,7 +479,7 @@
     var gl = this.contextGL;
     var program = this.shaderProgram;
 
-  if (this.type === "yuv420"){
+    if (this.type === "yuv420"){
 
       var yTextureRef = this.initTexture();
       var ySamplerRef = gl.getUniformLocation(program, 'ySampler');
@@ -514,8 +514,8 @@
 
     var textureRef = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, textureRef);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.bindTexture(gl.TEXTURE_2D, null);

--- a/README.markdown
+++ b/README.markdown
@@ -8,12 +8,12 @@ http://mbebenita.github.io/Broadway/foxDemo.html
 http://mbebenita.github.io/Broadway/storyDemo.html  
 http://mbebenita.github.io/Broadway/treeDemo.html  
 
-These demo video players first need to download the entire video before it can start playing, thus appearing to be a bit slow at first, so have patience. You can start the video by clicking on each player. The top left player runs on the main thread, the remaining players run in background worker threads.
+These demo video players first need to download the entire video before the can start playing. So they seem to be slow at first, so have patience. You can start the video by clicking on each player. The top left player runs on the main thread, and the remaining players run in background worker threads.
 
 Use a example node app as template:  
 https://github.com/soliton4/BroadwayStream  
 
-#Technical info
+# Technical info
 
 The demo is Android's H.264 decoder compiled with Emscripten to JavaScript, then further optimized with
 Google's JavaScript closure compiler and further optimized by hand to use WebGL.
@@ -27,15 +27,17 @@ The code for the demo is in the Decoder folder, to build it run the make.py pyth
 
 ## Encoding Video:
 
-Decoder.js expects H.264 NALUs. It does not support weighted prediction for P-frames and CABAC (arithmetic) entropy encoding. To meet these limitations, H.264 should be encoded with the Baseline Profile and CAVLC (Huffman-style) entropy encoding. 
+Decoder.js expects H.264 NALUs. It does not support weighted prediction for P-frames and CABAC (arithmetic) entropy encoding. To meet these limitations, Encode your video with the H.264 Baseline Profile and CAVLC (Huffman-style) entropy encoding. 
   
-The demo expects mp4 files containing H.264. It uses ffmpeg and x264 to convert mp4 files into streams of NALUs for Decoder.js. It uses the following command line options:
+The demo includes both a browser-based planer and a node.js web server app. The server expects mp4 files containing H.264. It uses ffmpeg and x264 to convert mp4 files into streams of NALUs for Decoder.js. It uses the following command line options:
 
 ```
 ffmpeg -y -i sourceFile -r 30000/1001 -b:a 2M -bt 4M -vcodec libx264 -pass 1 -coder 0 -bf 0 -flags -loop -wpredp 0 -an targetFile.mp4
 ```
 
-#API
+# API
+
+Use the API to build a web page containing a video viewer.
 
 Player.js, Decoder.js and YUVWebGLCanvas.js all have a unified module definition.  
 You can use them as plain js files or with common.js / AMD  
@@ -68,9 +70,7 @@ p.decode(<h264 data>);
 * `workerFile`: 
 path to Decoder.js. Only neccessary when using worker. defaults to `Decoder.js`
 * `webgl` (true / "auto" / false)  Use WebGL to render video. Defaults to "auto"  
-* `isScalable` (true / false)  
-* `size { width: w, height: h }`: an object containing the 
-initial size of the canvas. The canvas resizes after video starts streaming to match the dimensions of the video.  
+* `size { width: w, height: h }`: an object containing the initial size of the canvas. The canvas resizes after video starts streaming to match the dimensions of the video.  
 * `render`: (true / false) If this is false Broadway decodes but does not render the video stream. Defaults to true.
 * `targetScalable`: (true / false) If true, the video is scaled (magnified or shrunk) to a target size  on screen. If false, the video is drawn pixel-for-pixel at tbe actual size of the encoded video. Drawing preserves the aspect ratio (for example 16:9) of the encoded stream. Defaults to false.
 * `backgroundColor:` Color of the background color of the newly created canvas. Defaults to '#0D0E1B'.
@@ -79,8 +79,7 @@ initial size of the canvas. The canvas resizes after video starts streaming to m
 ## properties:  
 
 * `domNode`: the canvas object.  
-
-refers to the canvas element.  
+Refers to the canvas element.  
 
 ## methods:  
 
@@ -89,12 +88,12 @@ refers to the canvas element.
 Call this method as many times as required to pass it your video stream.
 
 Each buffer you pass to `decode()` must contain either
-* a single complete NALU encoded in the packet transport protocol, without any length information preceding the NALU, or
+* a single complete NALU encoded in the packet transport protocol with no length information preceding the NALU, or
 * a series of complete NALUs in the byte stream format, each preceded by a start code.
 
 Notice that `decode()` cannot process partial NALUs. 
 
-The optional `info` parameter is an object containing a `timestamp` value, a Javascript timestamp. \For example you can pass a timestamp using `Player.decode(buffer,  {timestamp:myTimestamp});
+The optional `info` parameter is an object containing a Javascript `timestamp`. For example you can pass a timestamp using `Player.decode(buffer,  {timestamp:myTimestamp});
 `
 Broadway does not do anything with your timestamps except pass them to event handlers.
 
@@ -104,11 +103,11 @@ To pace your video playback, call `decode()` at the right moment for each frame.
 
 This method has no effect unless the player instance is constructed with `targetScalable: true`.
 
-Invoke it with the width and height you want for the canvas on your page. This is the simplest way:
+Invoke it with the width and height you want for the canvas on your page. This is a simple invocation:
  
      player.setTargetDimensions({width: newWidth, height: newHeight});
  
-A good way to use it is in response to a 'resize' event for your browser window. In this example, when a user resizes a page, the event handler is called. The event handler looks at the dimensions of `containerDiv`, a part of the DOM that changes size. It  passes the (new) wwidth and height to `setTargetDimensions()`.
+A good way to use it is in response to a 'resize' event for your browser window. In this example, when a user resizes a page, the event handler is called. The event handler looks at the dimensions of `containerDiv`, a part of the DOM that changes size responsively. It  passes the (new) wwidth and height to `setTargetDimensions()`.
 
 ```js
     var containerDiv = window.getElementById('video_container');
@@ -119,16 +118,17 @@ A good way to use it is in response to a 'resize' event for your browser window.
     function resizeBroadway (event) {
       player.setTargetDimensions( containerDiv.getBoundingClientRect() );
     }
+    ...
     window.addEventListener('resize', resizeBroadway)
 ```
 
-If the new width and height do not match the aspect ratio of the decoded video stream, Broadway sets the canvas size to fill your desired width and height, but keeping the video aspect ratio.  It will place the canvas to the left, or to the top, of your containerDiv.
+If the new width and height do not match the aspect ratio of the decoded video stream, Broadway sets the canvas size to fill your desired width and height while preserving video aspect ratio.  It will place the canvas to the left, or to the top, of your containerDiv.
 
-If you are accustomed to using pure CSS to your web pages responsive, this way of handling the size of the video canvas may seem complex.  It is necessary because canvas objects cannot be resized with CSS, and because WebGL canvases require some initializing before they can be used.
+If you are accustomed to using pure CSS to make your web pages responsive, this way of handling the size of the video canvas may seem complex.  It is necessary because canvas objects cannot be resized with CSS, and because WebGL canvases require some initializing before they can be used.
 
 ### `setSourceDimensions (rect)`
 
-Use this method if the dimensions of your video source (for example a webcam) are not an even multiple of 16x16. H.264 inherently works on 16x16 *macroblocks*, and is not capable of handling partial macroblocks.
+Use this method if the dimensions of your video source (for example a webcam) are not an even multiple of 16x16. H.264 codecs inherently works on 16x16 *macroblocks*, and are not capable of handling partial macroblocks.
 
 For example, a webcam may capture video at a resolution of 292x230 pixels. In order for H.264 to handle those dimensions, it must pad them to 304x240, or 19x15 whole macroblocks.  That video stream, when decoded, contains a 12 pixel wide green bar at the right, and a 10 pxiel wide bar at the bottom, showing that the encoder has padded the source video.
 
@@ -136,7 +136,7 @@ If you know the actual size of the bitstream without the padding, you can invoke
 
 For this example, use
 
-    player.setSourceDimensions({width:191, height:330);
+    player.setSourceDimensions({width:192, height:330);
     
 These video source dimensions are not available from the H.264 stream of NALUs and must be obtained some other way  They do appear in mp4 and webm video container formats.
 
@@ -160,6 +160,7 @@ The rect object contains several members
 * `targetScalable`: true if the video is scaled before rendering
 * `timestamp`: the timestamp given to `decode()` if any
 
+Numbers are in pixels.
 
 ### `renderFrameComplete (rect)`
 
@@ -202,7 +203,7 @@ Are you gettng a blank canvas rather than decoded video?
 
 * Did you insert the player's canvas into your DOM? See the example code. 
 * Ensure your H.264 video is coded with the Baseline Profile and CAVLC entropy coding. By default many modern video encoders use the Main Profile and CABAC entropy coding. Broadway's decoder cannot handle video coded that way.
-* Pass only complete H.264 HALUs to the `decode()` method. Do not try to pass it the NALUs boxed in mp4 or webm container data streams. And, do not try to pass it partial NALUs.
+* Pass only complete H.264 HALUs to the `decode()` method. Do not try to pass it the NALUs boxed in mp4 or webm container data streams unless you debox them first. And, do not try to pass it partial NALUs.
 
 Do you see green or black bars to the right or bottom of your video?
 
@@ -210,8 +211,8 @@ Do you see green or black bars to the right or bottom of your video?
 
 Is Broadway very slow?
 
-* If your browser cannot handle WebGL rendering it may slow down. Broadway uses `console.log()` for a meesage when you ask for WebGL and the browser cannot deliver it.
-* Is your video datastream taking a long time to arrive at your browser? This could mean network or server trouble.
+* If your browser cannot handle WebGL rendering it may slow down. Broadway uses `console.log()` for a message when you ask for WebGL and the browser cannot deliver it.
+* Is your video datastream taking a long time to arrive at your browser? This could mean high network latency or server trouble.
 * Are the dimensions of the source video very large (for example 1920x1080)? Consider downsampling your video before encoding it. Broadway is pure Javascript, and does not perform as well as hardware-assisted decoders built into many devices.
 
 # [Real World Uses of Broadway.js](https://github.com/mbebenita/Broadway/wiki/Real-World-Uses)

--- a/README.markdown
+++ b/README.markdown
@@ -8,80 +8,164 @@ http://mbebenita.github.io/Broadway/foxDemo.html
 http://mbebenita.github.io/Broadway/storyDemo.html  
 http://mbebenita.github.io/Broadway/treeDemo.html  
 
-The video player first needs to download the entire video before it can start playing, thus appearing to be a bit slow at first, so have patience. You can start the video by clicking on each player. The top left player runs on the main thread, the remaining players run in background worker threads.
+These demo video players first need to download the entire video before it can start playing, thus appearing to be a bit slow at first, so have patience. You can start the video by clicking on each player. The top left player runs on the main thread, the remaining players run in background worker threads.
 
 Use a example node app as template:  
 https://github.com/soliton4/BroadwayStream  
 
-Technical info
-==============
+#Technical info
 
 The demo is Android's H.264 decoder compiled with Emscripten to JavaScript, then further optimized with
 Google's JavaScript closure compiler and further optimized by hand to use WebGL.
 
-Building the demo:
+## Building the demo:
 
 Install and configure Emscripten (https://github.com/kripken/emscripten)  
 The current version of Broadway was built with emscripten 1.35.12  
 
 The code for the demo is in the Decoder folder, to build it run the make.py python script. (Requires at least python 2.7)
 
-Encoding Video
-==============
+## Encoding Video:
 
-The decoder expects an .mp4 file and does not support weighted prediction for P-frames and CABAC entropy encoding. To create such bitstreams use ffmpeg and x264 with the following command line options:
+Decoder.js expects H.264 NALUs. It does not support weighted prediction for P-frames and CABAC (arithmetic) entropy encoding. To meet these limitations, H.264 should be encoded with the Baseline Profile and CAVLC (Huffman-style) entropy encoding. 
+  
+The demo expects mp4 files containing H.264. It uses ffmpeg and x264 to convert mp4 files into streams of NALUs for Decoder.js. It uses the following command line options:
 
 ```
 ffmpeg -y -i sourceFile -r 30000/1001 -b:a 2M -bt 4M -vcodec libx264 -pass 1 -coder 0 -bf 0 -flags -loop -wpredp 0 -an targetFile.mp4
 ```
 
-API
-===
+#API
 
 Player.js, Decoder.js and YUVWebGLCanvas.js all have a unified module definition.  
 You can use them as plain js files or with common.js / AMD  
 
 # Player.js:  
 
+You only need construct a Player object to use Broadway. It takes care of constructing the needed objects for decoding and rendering.
+
+The Player constructor creates a new `<canvas>` to render the video. The new canvas is not visible until it is inserted into the web page using `.appendChild(player.domNode)` or an equivalent way of manipulating the pages's DOM.
+
+Basic usage is simple: 
+
+1. Construct a player instance
+2. Insert its canvas into the DOM
+3. Invoke the `decode()` method as long as you have encoded video data to display
+
 ```
-var p = new Player({
+var containerDiv = window.getElementById('video_container');
+var player = new Player({
   <options>
 });
-
-p.canvas; // the canvas - put it where you want it
-
+containerDiv.appendChild(player.domNode); 
+...
 p.decode(<h264 data>);
 ```
 
 ## options:  
 
-useWorker true / false  
-decode in a worker thread  
+* `useWorker`: (true / false) decode in a worker thread. Defaults to false, but should be set to true on modern browsers.  
+* `workerFile`: 
+path to Decoder.js. Only neccessary when using worker. defaults to `Decoder.js`
+* `webgl` (true / "auto" / false)  Use WebGL to render video. Defaults to "auto"  
+* `isScalable` (true / false)  
+* `size { width: w, height: h }`: an object containing the 
+initial size of the canvas. The canvas resizes after video starts streaming to match the dimensions of the video.  
+* `render`: (true / false) If this is false Broadway decodes but does not render the video stream. Defaults to true.
+* `targetScalable`: (true / false) If true, the video is scaled (magnified or shrunk) to a target size  on screen. If false, the video is drawn pixel-for-pixel at tbe actual size of the encoded video. Drawing preserves the aspect ratio (for example 16:9) of the encoded stream. Defaults to false.
+* `backgroundColor:` Color of the background color of the newly created canvas. Defaults to '#0D0E1B'.
 
-workerFile <string>  
-path to Decoder.js. Only neccessary when using worker. defaults to "Decoder.js"  
-
-webgl true / "auto" / false  
-use webgl. defaults to "auto"  
-
-size { width: <num>, height: <num> }  
-initial size of the canvas. canvas will resize after video starts streaming.  
 
 ## properties:  
 
-canvas  
-domNode  
+* `domNode`: the canvas object.  
 
 refers to the canvas element.  
 
 ## methods:  
 
-decode (<bin>)
+### `decode(buffer [, info])`
 
-feed the decoder with h264 stream data.  
+Call this method as many times as required to pass it your video stream.
 
+Each buffer you pass to `decode()` must contain either
+* a single complete NALU encoded in the packet transport protocol, without any length information preceding the NALU, or
+* a series of complete NALUs in the byte stream format, each preceded by a start code.
+
+Notice that `decode()` cannot process partial NALUs. 
+
+The optional `info` parameter is an object containing a `timestamp` value, a Javascript timestamp. \For example you can pass a timestamp using `Player.decode(buffer,  {timestamp:myTimestamp});
+`
+Broadway does not do anything with your timestamps except pass them to event handlers.
+
+To pace your video playback, call `decode()` at the right moment for each frame.
+
+### `setTargetDimensions (rect)`
+
+This method has no effect unless the player instance is constructed with `targetScalable: true`.
+
+Invoke it with the width and height you want for the canvas on your page. This is the simplest way:
+ 
+     player.setTargetDimensions({width: newWidth, height: newHeight});
+ 
+A good way to use it is in response to a 'resize' event for your browser window. In this example, when a user resizes a page, the event handler is called. The event handler looks at the dimensions of `containerDiv`, a part of the DOM that changes size. It  passes the (new) wwidth and height to `setTargetDimensions()`.
+
+```js
+    var containerDiv = window.getElementById('video_container');
+    ...
+    var player = new Player (...);
+    containerDiv.appendChild(player.domNode);
+    ...
+    function resizeBroadway (event) {
+      player.setTargetDimensions( containerDiv.getBoundingClientRect() );
+    }
+    window.addEventListener('resize', resizeBroadway)
+```
+
+If the new width and height do not match the aspect ratio of the decoded video stream, Broadway sets the canvas size to fill your desired width and height, but keeping the video aspect ratio.  It will place the canvas to the left, or to the top, of your containerDiv.
+
+### `setSourceDimensions (rect)`
+
+Use this method if the dimensions of your video source (for example a webcam) are not an even multiple of 16x16. H.264 inherently works on 16x16 *macroblocks*, and is not capable of handling partial macroblocks.
+
+For example, a webcam may capture video at a resolution of 292x230 pixels. In order for H.264 to handle those dimensions, it must pad them to 304x240, or 19x15 whole macroblocks.  That video stream, when decoded, contains a 12 pixel wide green bar at the right, and a 10 pxiel wide bar at the bottom, showing that the encoder has padded the source video.
+
+If you know the actual size of the bitstream without the padding, you can invoke `setSourceDimensions()`. Then Broadway will conceal the padding when it renders the video.
+
+For this example, use
+
+    player.setSourceDimensions({width:191, height:330);
+    
+These video source dimensions are not available from the H.264 stream of NALUs and must be obtained some other way  They do appear in mp4 and webm video container formats.
+
+## events:
+
+### `frameSizeChange (info)`
+
+This event is fired when the video changes size. To get this event, use code like this:
+
+    player.onFrameSizeChange ( function (rect) {
+       ...
+    });
+    
+The rect object contains several members
+* `targetWidth`: the width set by setTarget dimensions after correction for aspect ratio
+* `targetHeight`: the height set by setTarget dimensions after correction for aspect ratio
+* `sourceWidth`: the width set by  setSourceDimensions
+* `sourceHeight`: the height set by setSourceDimensions
+* `decodedWidth`: the width of the decoded video stream, a multiple of 16.
+* `decodedHeight`: the height of the decoded video stream, a multiple of 16.
+* `targetScalable`: true if the video is scaled before rendering
+* `timestamp`: the timestamp given to `decode()` if any
+
+
+### `renderFrameComplete (rect)`
+
+This event is fired after each frame is rendered. It  is used like the 'frameSizeChange' event.
 
 # Decoder.js:  
+
+The Decoder may be used alone. However, if you use the Player, it manages the Decoder for you.
 
 ```
 var p = new Decoder({
@@ -106,9 +190,27 @@ will be called for each frame.
 
 ## methods:  
 
-decode (<bin>)
+decode (<bin> [, options])
 
-feed the decoder with h264 stream data.  
+feed the decoder with h264 stream data. 
 
+# Troubleshooting
+
+Are you gettng a blank canvas rather than decoded video?
+
+* Did you insert the player's canvas into your DOM? See the example code. 
+* Ensure your H.264 video is coded with the Baseline Profile and CAVLC entropy coding. By default many modern video encoders use the Main Profile and CABAC entropy coding. Broadway's decoder cannot handle video coded that way.
+* Pass only complete H.264 HALUs to the `decode()` method. Do not try to pass it the NALUs boxed in mp4 or webm container data streams. And, do not try to pass it partial NALUs.
+
+Do you see green or black bars to the right or bottom of your video?
+
+* See `setTargetDimensions()` above.
+
+Is Broadway very slow?
+
+* If your browser cannot handle WebGL rendering it may slow down. Broadway uses `console.log()` for a meesage when you ask for WebGL and the browser cannot deliver it.
+* Is your video datastream taking a long time to arrive at your browser? This could mean network or server trouble.
+* Are the dimensions of the source video very large (for example 1920x1080)? Consider downsampling your video before encoding it. Broadway is pure Javascript, and does not perform as well as hardware-assisted decoders built into many devices.
 
 # [Real World Uses of Broadway.js](https://github.com/mbebenita/Broadway/wiki/Real-World-Uses)
+

--- a/README.markdown
+++ b/README.markdown
@@ -124,6 +124,8 @@ A good way to use it is in response to a 'resize' event for your browser window.
 
 If the new width and height do not match the aspect ratio of the decoded video stream, Broadway sets the canvas size to fill your desired width and height, but keeping the video aspect ratio.  It will place the canvas to the left, or to the top, of your containerDiv.
 
+If you are accustomed to using pure CSS to your web pages responsive, this way of handling the size of the video canvas may seem complex.  It is necessary because canvas objects cannot be resized with CSS, and because WebGL canvases require some initializing before they can be used.
+
 ### `setSourceDimensions (rect)`
 
 Use this method if the dimensions of your video source (for example a webcam) are not an even multiple of 16x16. H.264 inherently works on 16x16 *macroblocks*, and is not capable of handling partial macroblocks.


### PR DESCRIPTION
Per your request, I have restored the whitespace as I found it in the master

This PR adds code to Player.js and YUVCanvas.js to handle resizing decoded video and scaling it up or down to fit the format of the web page in which it is used.

WebGL handles scaled video with the same high efficiency it has for unscaled video.  The RGB rendering is a little slower, because it must draw to one hidden canvas, and then use a scaled drawImage to copy each frame to a visible canvas.

The README file now contains more details.

Thanks for a great job with Broadway! I think some Broadway users will find this scaling capability as useful as I have.